### PR TITLE
feat: notify Telegram on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A small CLI utility that watches a list of Twitch logins and sends a Telegram me
 - Polls Twitch Helix `/users` API and checks the `broadcaster_type`.
 - Persists state in `.subs_status.json` to avoid duplicate notifications.
 - Sends formatted notifications to a Telegram chat using a bot token.
+- Announces start and graceful shutdown in the Telegram chat.
 
 ## Requirements
 - Python 3.12+

--- a/main.py
+++ b/main.py
@@ -230,6 +230,14 @@ def cmd_watch(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         # Тихо выходим
         logger.info("Watcher stopped by user")
+        try:
+            send_telegram_message(
+                tg_token,
+                tg_chat,
+                "🔴 <b>Twitch Subs Watcher</b> остановлен.",
+            )
+        except Exception:
+            pass
         return 0
 
 


### PR DESCRIPTION
## Summary
- notify Telegram chat when watcher stops
- document start and shutdown announcements

## Testing
- `uv run main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a2fdafb39c8325bd3758a46ef61f97