### PR TITLE
refactor: decouple application from infrastructure

### DIFF
--- a/src/twitch_subs/application/watcher.py
+++ b/src/twitch_subs/application/watcher.py
@@ -8,9 +8,11 @@ from typing import Iterable
 from loguru import logger
 
 from ..domain.models import BroadcasterType, UserRecord
-from ..infrastructure.state import StateRepository
-from ..infrastructure.telegram import TelegramNotifier
-from ..infrastructure.twitch import TwitchClient
+from ..domain.ports import (
+    NotifierProtocol,
+    StateRepositoryProtocol,
+    TwitchClientProtocol,
+)
 
 
 @dataclass(frozen=True)
@@ -27,9 +29,9 @@ class Watcher:
 
     def __init__(
         self,
-        twitch: TwitchClient,
-        notifier: TelegramNotifier,
-        state_repo: StateRepository,
+        twitch: TwitchClientProtocol,
+        notifier: NotifierProtocol,
+        state_repo: StateRepositoryProtocol,
     ) -> None:
         self.twitch = twitch
         self.notifier = notifier

--- a/src/twitch_subs/domain/ports.py
+++ b/src/twitch_subs/domain/ports.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .models import BroadcasterType, UserRecord
+
+
+class TwitchClientProtocol(Protocol):
+    def get_user_by_login(self, login: str) -> UserRecord | None: ...
+
+
+class NotifierProtocol(Protocol):
+    def send_message(self, text: str, disable_web_page_preview: bool = True) -> None: ...
+
+
+class StateRepositoryProtocol(Protocol):
+    def load(self) -> dict[str, BroadcasterType]: ...
+    def save(self, state: dict[str, BroadcasterType]) -> None: ...

--- a/src/twitch_subs/infrastructure/state.py
+++ b/src/twitch_subs/infrastructure/state.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import Dict
 
 from ..domain.models import BroadcasterType
+from ..domain.ports import StateRepositoryProtocol
 
 
-class StateRepository:
+class StateRepository(StateRepositoryProtocol):
     def __init__(self, path: Path | None = None):
         self.path = path or Path(".subs_status.json")
 

--- a/src/twitch_subs/infrastructure/telegram.py
+++ b/src/twitch_subs/infrastructure/telegram.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import httpx
 from loguru import logger
 
+from ..domain.ports import NotifierProtocol
+
 TELEGRAM_API_BASE = "https://api.telegram.org"
 
 
-class TelegramNotifier:
+class TelegramNotifier(NotifierProtocol):
     def __init__(self, token: str, chat_id: str):
         self.token = token
         self.chat_id = chat_id

--- a/src/twitch_subs/infrastructure/twitch.py
+++ b/src/twitch_subs/infrastructure/twitch.py
@@ -5,12 +5,13 @@ from typing import Self
 import httpx
 
 from ..domain.models import BroadcasterType, TwitchAppCreds, UserRecord
+from ..domain.ports import TwitchClientProtocol
 
 TWITCH_TOKEN_URL = "https://id.twitch.tv/oauth2/token"
 TWITCH_USERS_URL = "https://api.twitch.tv/helix/users"
 
 
-class TwitchClient:
+class TwitchClient(TwitchClientProtocol):
     def __init__(self, token: str, cliend_id: str):
         self._token: str = token
         self._client_id = cliend_id

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -2,20 +2,22 @@ from typing import Dict
 
 from twitch_subs.application.watcher import Watcher
 from twitch_subs.domain.models import BroadcasterType, UserRecord
-from twitch_subs.infrastructure.state import StateRepository
-from twitch_subs.infrastructure.telegram import TelegramNotifier
-from twitch_subs.infrastructure.twitch import TwitchClient
+from twitch_subs.domain.ports import (
+    NotifierProtocol,
+    StateRepositoryProtocol,
+    TwitchClientProtocol,
+)
 
 
-class DummyNotifier(TelegramNotifier):
-    def __init__(self) -> None:  # type: ignore[override]
+class DummyNotifier(NotifierProtocol):
+    def __init__(self) -> None:
         self.sent: list[str] = []
 
-    def send_message(self, text: str, _: bool = True) -> None:  # type: ignore[override]
+    def send_message(self, text: str, _: bool = True) -> None:
         self.sent.append(text)
 
 
-class DummyTwitch(TwitchClient):
+class DummyTwitch(TwitchClientProtocol):
     def __init__(self, users: dict[str, UserRecord | None]):
         self.users = users
 
@@ -23,14 +25,14 @@ class DummyTwitch(TwitchClient):
         return self.users.get(login)
 
 
-class DummyState(StateRepository):
+class DummyState(StateRepositoryProtocol):
     def __init__(self) -> None:
         self.data: Dict[str, BroadcasterType] = {}
 
-    def load(self) -> Dict[str, BroadcasterType]:  # type: ignore[override]
+    def load(self) -> Dict[str, BroadcasterType]:
         return self.data
 
-    def save(self, state: Dict[str, BroadcasterType]) -> None:  # type: ignore[override]
+    def save(self, state: Dict[str, BroadcasterType]) -> None:
         self.data = state
 
 


### PR DESCRIPTION
## Summary
- add domain-level protocols for Twitch, Telegram, and state services
- refactor watcher to depend on service protocols instead of infrastructure
- update infrastructure implementations and tests to satisfy protocols

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a35b23bb188325af372543ed482486