### PR TITLE
test: expand unit test coverage

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+from twitch_subs import cli
+
+
+def test_cli_watch_invokes_watcher(monkeypatch) -> None:
+    # Set required environment variables
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "chat")
+    monkeypatch.setenv("TWITCH_CLIENT_ID", "id")
+    monkeypatch.setenv("TWITCH_CLIENT_SECRET", "secret")
+
+    # Avoid loading actual .env file
+    monkeypatch.setattr(cli, "load_dotenv", lambda: None)
+
+    # Provide fake implementations for dependencies
+    class DummyTwitch:
+        @classmethod
+        def from_creds(cls, creds):  # noqa: D401
+            return cls()
+
+    class DummyNotifier:
+        def __init__(self, token: str, chat_id: str) -> None:  # noqa: D401
+            self.token = token
+            self.chat_id = chat_id
+
+        def send_message(self, text: str, disable_web_page_preview: bool = True) -> None:  # noqa: D401
+            pass
+
+    class DummyStateRepo:
+        def load(self) -> dict[str, Any]:  # noqa: D401
+            return {}
+
+        def save(self, state: dict[str, Any]) -> None:  # noqa: D401
+            pass
+
+    monkeypatch.setattr(cli, "TwitchClient", DummyTwitch)
+    monkeypatch.setattr(cli, "TelegramNotifier", DummyNotifier)
+    monkeypatch.setattr(cli, "StateRepository", lambda: DummyStateRepo())
+
+    calls: dict[str, Any] = {}
+
+    def fake_watch(self, logins, interval, stop_event=None):  # noqa: D401
+        calls["logins"] = logins
+        calls["interval"] = interval
+
+    monkeypatch.setattr(cli.Watcher, "watch", fake_watch, raising=False)
+
+    assert cli.main(["watch", "foo", "foo", "bar", "--interval", "1"]) == 0
+    assert calls["logins"] == ["foo", "bar"]  # duplicates removed
+    assert calls["interval"] == 1

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,18 @@
+import pytest
+
+from twitch_subs.infrastructure.env import require_env
+
+
+def test_require_env_returns_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FOO", "bar")
+    assert require_env("FOO") == "bar"
+
+
+@pytest.mark.parametrize("value,action", [("", "set"), (None, "del")])
+def test_require_env_missing(monkeypatch: pytest.MonkeyPatch, value: str | None, action: str) -> None:
+    if action == "set":
+        monkeypatch.setenv("FOO", value or "")
+    else:
+        monkeypatch.delenv("FOO", raising=False)
+    with pytest.raises(RuntimeError):
+        require_env("FOO")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,12 @@
+from twitch_subs.domain.exceptions import AppException, SigTerm
+
+
+def test_app_exception_message() -> None:
+    e = AppException()
+    assert e.message() == "Application error"
+
+
+def test_sigterm_message_and_inheritance() -> None:
+    e = SigTerm()
+    assert e.message() == "Received SIGTERM"
+    assert isinstance(e, AppException)

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,0 +1,45 @@
+from twitch_subs.domain.models import BroadcasterType, UserRecord
+from twitch_subs.domain.ports import (
+    NotifierProtocol,
+    StateRepositoryProtocol,
+    TwitchClientProtocol,
+)
+
+
+def test_twitch_client_protocol_subclass() -> None:
+    class Impl(TwitchClientProtocol):
+        def get_user_by_login(self, login: str) -> UserRecord | None:  # noqa: D401
+            return None
+
+    impl = Impl()
+    assert impl.get_user_by_login("foo") is None
+
+
+def test_notifier_protocol_subclass() -> None:
+    class Impl(NotifierProtocol):
+        def __init__(self) -> None:  # noqa: D401
+            self.sent: list[tuple[str, bool]] = []
+
+        def send_message(self, text: str, disable_web_page_preview: bool = True) -> None:  # noqa: D401
+            self.sent.append((text, disable_web_page_preview))
+
+    impl = Impl()
+    impl.send_message("hi", False)
+    assert impl.sent == [("hi", False)]
+
+
+def test_state_repository_protocol_subclass() -> None:
+    class Impl(StateRepositoryProtocol):
+        def __init__(self) -> None:  # noqa: D401
+            self.saved: dict[str, BroadcasterType] | None = None
+
+        def load(self) -> dict[str, BroadcasterType]:  # noqa: D401
+            return {}
+
+        def save(self, state: dict[str, BroadcasterType]) -> None:  # noqa: D401
+            self.saved = state
+
+    impl = Impl()
+    assert impl.load() == {}
+    impl.save({"foo": BroadcasterType.NONE})
+    assert impl.saved == {"foo": BroadcasterType.NONE}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -10,3 +10,15 @@ def test_state_roundtrip(tmp_path: Path) -> None:
     repo.save(state)
     loaded = repo.load()
     assert loaded == state
+
+
+def test_load_returns_empty_when_missing(tmp_path: Path) -> None:
+    repo = StateRepository(tmp_path / "state.json")
+    assert repo.load() == {}
+
+
+def test_load_returns_empty_on_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "state.json"
+    path.write_text("not-json")
+    repo = StateRepository(path)
+    assert repo.load() == {}

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,0 +1,61 @@
+import httpx
+
+from twitch_subs.infrastructure.telegram import (
+    TELEGRAM_API_BASE,
+    TelegramNotifier,
+)
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.status_checked = False
+
+    def raise_for_status(self) -> None:
+        self.status_checked = True
+
+
+class DummyClient:
+    def __init__(self, *args, **kwargs) -> None:
+        self.posts: list[tuple[str, dict]] = []
+
+    def __enter__(self) -> "DummyClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401
+        pass
+
+    def post(self, url: str, json: dict) -> DummyResponse:
+        self.posts.append((url, json))
+        return DummyResponse()
+
+
+def test_send_message_builds_request(monkeypatch) -> None:
+    client = DummyClient()
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: client)
+    notifier = TelegramNotifier("tok", "chat")
+    notifier.send_message("hello", disable_web_page_preview=False)
+    assert client.posts
+    url, payload = client.posts[0]
+    assert url == f"{TELEGRAM_API_BASE}/bot{'tok'}/sendMessage"
+    assert payload["chat_id"] == "chat"
+    assert payload["text"] == "hello"
+    assert payload["disable_web_page_preview"] is False
+
+
+def test_send_message_swallow_errors(monkeypatch) -> None:
+    class FailClient:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        def __enter__(self) -> "FailClient":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401
+            pass
+
+        def post(self, url: str, json: dict) -> None:
+            raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: FailClient())
+    notifier = TelegramNotifier("tok", "chat")
+    notifier.send_message("hi")  # should not raise

--- a/tests/test_twitch.py
+++ b/tests/test_twitch.py
@@ -1,0 +1,88 @@
+import httpx
+
+from twitch_subs.domain.models import BroadcasterType, TwitchAppCreds
+from twitch_subs.infrastructure.twitch import (
+    TWITCH_TOKEN_URL,
+    TWITCH_USERS_URL,
+    TwitchClient,
+)
+
+
+class DummyResponse:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+        self.status_checked = False
+
+    def json(self) -> dict:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        self.status_checked = True
+
+
+class DummyClient:
+    def __init__(self, responses: list[DummyResponse]) -> None:
+        self.responses = responses
+        self.requests: list[tuple] = []
+
+    def __enter__(self) -> "DummyClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401
+        pass
+
+    def post(self, url: str, data: dict | None = None) -> DummyResponse:
+        self.requests.append(("POST", url, data))
+        return self.responses.pop(0)
+
+    def get(self, url: str, headers: dict | None = None, params: dict | None = None) -> DummyResponse:
+        self.requests.append(("GET", url, headers, params))
+        return self.responses.pop(0)
+
+
+def test_from_creds_requests_token(monkeypatch) -> None:
+    responses = [DummyResponse({"access_token": "abc"})]
+    client = DummyClient(responses)
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: client)
+    creds = TwitchAppCreds(client_id="id", client_secret="secret")
+    twitch = TwitchClient.from_creds(creds)
+    assert isinstance(twitch, TwitchClient)
+    method, url, data = client.requests[0]
+    assert method == "POST" and url == TWITCH_TOKEN_URL
+    assert data["client_id"] == "id"
+
+
+def test_get_user_by_login_returns_user(monkeypatch) -> None:
+    responses = [
+        DummyResponse(
+            {
+                "data": [
+                    {
+                        "id": "1",
+                        "login": "foo",
+                        "display_name": "Foo",
+                        "broadcaster_type": "partner",
+                    }
+                ]
+            }
+        )
+    ]
+    client = DummyClient(responses)
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: client)
+    twitch = TwitchClient("tok", "id")
+    user = twitch.get_user_by_login("foo")
+    assert user and user.login == "foo"
+    assert user.broadcaster_type == BroadcasterType.PARTNER
+    method, url, headers, params = client.requests[0]
+    assert method == "GET" and url == TWITCH_USERS_URL
+    assert params == {"login": "foo"}
+    assert headers["Authorization"] == "Bearer tok"
+
+
+def test_get_user_by_login_not_found(monkeypatch) -> None:
+    responses = [DummyResponse({"data": []})]
+    client = DummyClient(responses)
+    monkeypatch.setattr(httpx, "Client", lambda *a, **k: client)
+    twitch = TwitchClient("tok", "id")
+    user = twitch.get_user_by_login("bar")
+    assert user is None

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -68,3 +68,17 @@ def test_run_once_updates_state_and_notifies() -> None:
     assert changed is True
     assert state["foo"] == BroadcasterType.AFFILIATE
     assert notifier.sent
+
+
+def test_run_once_no_change_does_not_notify() -> None:
+    users = {"foo": UserRecord("1", "foo", "Foo", BroadcasterType.AFFILIATE)}
+    twitch = DummyTwitch(users)
+    notifier = DummyNotifier()
+    state_repo = DummyState()
+    watcher = Watcher(twitch, notifier, state_repo)
+
+    state: Dict[str, BroadcasterType] = {"foo": BroadcasterType.AFFILIATE}
+    changed = watcher.run_once(["foo"], state)
+
+    assert changed is False
+    assert not notifier.sent


### PR DESCRIPTION
## Summary
- add protocol, environment, telegram, twitch, and CLI unit tests
- extend state and watcher tests for edge cases

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a35d287eec832597170ebbf9657473