### PR TITLE
feat: add Telegram watchlist management bot

### DIFF
--- a/src/twitch_subs/infrastructure/telegram.py
+++ b/src/twitch_subs/infrastructure/telegram.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 from loguru import logger
 
 from ..domain.ports import NotifierProtocol
+from . import watchlist
 
 TELEGRAM_API_BASE = "https://api.telegram.org"
 
@@ -34,3 +37,61 @@ class TelegramNotifier(NotifierProtocol):
                 r.raise_for_status()
         except Exception:
             logger.exception("Telegram send failed")
+
+
+class TelegramWatchlistBot:
+    """Minimal Telegram bot to manage the watchlist."""
+
+    def __init__(self, token: str, path: Path | None = None) -> None:
+        self.token = token
+        self.path = watchlist.resolve_path(path)
+
+    def _api_url(self, method: str) -> str:
+        return f"{TELEGRAM_API_BASE}/bot{self.token}/{method}"
+
+    def _send_message(self, chat_id: int, text: str) -> None:
+        payload = {"chat_id": chat_id, "text": text}
+        try:
+            with httpx.Client(timeout=15.0) as c:
+                r = c.post(self._api_url("sendMessage"), json=payload)
+                r.raise_for_status()
+        except Exception:
+            logger.exception("Telegram send failed")
+
+    def handle_command(self, text: str) -> str:
+        parts = text.strip().split(maxsplit=1)
+        cmd = parts[0]
+        arg = parts[1].strip() if len(parts) > 1 else None
+        if cmd == "/add" and arg:
+            if watchlist.add(self.path, arg):
+                return f"Added {arg}"
+            return f"{arg} already present"
+        if cmd == "/remove" and arg:
+            if watchlist.remove(self.path, arg):
+                return f"Removed {arg}"
+            return f"{arg} not found"
+        if cmd == "/list" and not arg:
+            users = watchlist.load(self.path)
+            if users:
+                return "\n".join(users)
+            return "Watchlist is empty"
+        return "Unknown command"
+
+    def poll(self, offset: int | None = None) -> int | None:
+        params: dict[str, int] = {"timeout": 25}
+        if offset is not None:
+            params["offset"] = offset
+        with httpx.Client(timeout=30.0) as c:
+            r = c.get(self._api_url("getUpdates"), params=params)
+            r.raise_for_status()
+            data = r.json()
+        for update in data.get("result", []):
+            offset = update["update_id"] + 1
+            message = update.get("message") or {}
+            text = message.get("text")
+            chat_id = (message.get("chat") or {}).get("id")
+            if not text or chat_id is None:
+                continue
+            reply = self.handle_command(text)
+            self._send_message(chat_id, reply)
+        return offset

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from twitch_subs.infrastructure.telegram import TelegramWatchlistBot
+from twitch_subs.infrastructure import watchlist
+
+
+def test_bot_add_remove_list(tmp_path: Path) -> None:
+    path = tmp_path / "watchlist.json"
+    bot = TelegramWatchlistBot("token", path)
+
+    assert bot.handle_command("/list") == "Watchlist is empty"
+
+    assert bot.handle_command("/add foo") == "Added foo"
+    assert watchlist.load(path) == ["foo"]
+
+    assert "foo" in bot.handle_command("/list")
+
+    assert bot.handle_command("/remove foo") == "Removed foo"
+    assert watchlist.load(path) == []
+    assert bot.handle_command("/list") == "Watchlist is empty"
+
+
+def test_bot_duplicate_and_missing(tmp_path: Path) -> None:
+    path = tmp_path / "watchlist.json"
+    bot = TelegramWatchlistBot("token", path)
+    bot.handle_command("/add foo")
+
+    assert bot.handle_command("/add foo") == "foo already present"
+    assert bot.handle_command("/remove bar") == "bar not found"


### PR DESCRIPTION
## Summary
- add TelegramWatchlistBot with `/add`, `/remove`, `/list` commands
- expose bot via new `bot` CLI command
- test Telegram watchlist bot behavior

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d5c9e51c8325b927c00665a7a0f6