### PR TITLE
feat(cli): add graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A small CLI utility that watches a list of Twitch logins and sends a Telegram me
 - Stores Twitch logins in a local SQLite database and provides CLI commands to manage it.
 - Sends formatted notifications to a Telegram chat using a bot token.
 - Announces start and graceful shutdown in the Telegram chat.
+ - Gracefully handles SIGINT/SIGTERM and stops the watcher thread cleanly.
 
 ## Installation
 
@@ -71,6 +72,11 @@ Run the test suite:
 ```bash
 uv run pytest
 ```
+
+### Docker
+
+The provided `dockerfile` uses [tini](https://github.com/krallin/tini) as PID 1
+so that `docker stop` (SIGTERM followed by SIGKILL) results in a clean shutdown.
 
 ## License
 Released under the terms of the GNU General Public License v3.0. See [LICENSE](LICENSE) for details.

--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM ghcr.io/astral-sh/uv:alpine
 
+RUN apk add --no-cache tini
+
 WORKDIR /app
 
 # Copy dependency files and install
@@ -11,4 +13,4 @@ RUN uv sync --frozen --no-dev
 COPY . .
 
 # Default to running the CLI; additional args can be passed at runtime
-ENTRYPOINT ["uv", "run", "src/main.py"]
+ENTRYPOINT ["tini", "-g", "--", "uv", "run", "src/main.py"]

--- a/src/twitch_subs/application/watcher.py
+++ b/src/twitch_subs/application/watcher.py
@@ -102,9 +102,11 @@ class Watcher:
         self,
         logins: LoginsProvider,
         interval: int,
-        stop_event: threading.Event | None = None,
+        stop_event: threading.Event,
         report_interval: int = 86400,
     ) -> None:
+        """Run the watcher until *stop_event* is set."""
+
         state = self.state_repo.load()
         all_logins = logins.get()
         self.notifier.send_message(
@@ -114,7 +116,7 @@ class Watcher:
         next_report = time.time() + report_interval
         checks = 0
         errors = 0
-        while not (stop_event and stop_event.is_set()):
+        while not stop_event.is_set():
             checks += 1
             all_logins = logins.get()
             try:
@@ -130,7 +132,4 @@ class Watcher:
                 checks = 0
                 errors = 0
                 next_report += report_interval
-            if stop_event:
-                stop_event.wait(interval)
-            else:
-                time.sleep(interval)
+            stop_event.wait(interval)


### PR DESCRIPTION
## Summary
- handle SIGINT/SIGTERM and stop watcher thread via Event
- install tini and document graceful shutdown
- test clean exits of watcher and CLI

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac96915aac8325b9736885c5a2a41a