### PR TITLE
feat: introduce watchlist service and refactor bot

### DIFF
--- a/src/twitch_subs/application/__init__.py
+++ b/src/twitch_subs/application/__init__.py
@@ -1,0 +1,3 @@
+from .watchlist_service import WatchlistService
+
+__all__ = ["WatchlistService"]

--- a/src/twitch_subs/application/watchlist_service.py
+++ b/src/twitch_subs/application/watchlist_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from ..domain.ports import WatchlistRepository
+
+
+class WatchlistService:
+    """High level API for watchlist operations."""
+
+    def __init__(self, repo: WatchlistRepository) -> None:
+        self.repo = repo
+
+    def add(self, login: str) -> bool:
+        """Add *login* to the watchlist.
+
+        Returns ``True`` if added, ``False`` if already present.
+        """
+        if self.repo.exists(login):
+            return False
+        self.repo.add(login)
+        return True
+
+    def remove(self, login: str) -> bool:
+        """Remove *login* from the watchlist.
+
+        Returns ``True`` if *login* was present and removed.
+        """
+        return self.repo.remove(login)
+
+    def list(self) -> list[str]:
+        """Return all logins sorted alphabetically."""
+        return self.repo.list()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,9 +30,9 @@ class DummyNotifier:
 
 
 class DummyBot:
-    def __init__(self, token: str, id: str, repo: Any | None = None) -> None:  # noqa: D401
+    def __init__(self, token: str, id: str, service: Any | None = None) -> None:  # noqa: D401
         _ = token
-        _ = repo
+        _ = service
         _ = id
 
     async def run(self) -> None:  # noqa: D401

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from twitch_subs.application.watchlist_service import WatchlistService
 from twitch_subs.infrastructure.repository_sqlite import SqliteWatchlistRepository
 from twitch_subs.infrastructure.telegram import TelegramWatchlistBot
 
@@ -7,7 +8,8 @@ from twitch_subs.infrastructure.telegram import TelegramWatchlistBot
 def test_bot_add_remove_list(tmp_path: Path) -> None:
     db = tmp_path / "watch.db"
     repo = SqliteWatchlistRepository(f"sqlite:///{db}")
-    bot = TelegramWatchlistBot("123:ABC", "1", repo)
+    service = WatchlistService(repo)
+    bot = TelegramWatchlistBot("123:ABC", "1", service)
 
     assert bot.handle_command("/list") == "Watchlist is empty"
 
@@ -24,7 +26,8 @@ def test_bot_add_remove_list(tmp_path: Path) -> None:
 def test_bot_duplicate_and_missing(tmp_path: Path) -> None:
     db = tmp_path / "watch.db"
     repo = SqliteWatchlistRepository(f"sqlite:///{db}")
-    bot = TelegramWatchlistBot("123:ABC", "1", repo)
+    service = WatchlistService(repo)
+    bot = TelegramWatchlistBot("123:ABC", "1", service)
     bot.handle_command("/add foo")
 
     assert bot.handle_command("/add foo") == "foo already present"

--- a/tests/test_watchlist_service.py
+++ b/tests/test_watchlist_service.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from twitch_subs.application.watchlist_service import WatchlistService
+from twitch_subs.infrastructure.repository_sqlite import SqliteWatchlistRepository
+
+
+def test_watchlist_service_crud(tmp_path: Path) -> None:
+    db = tmp_path / "watch.db"
+    repo = SqliteWatchlistRepository(f"sqlite:///{db}")
+    service = WatchlistService(repo)
+
+    assert service.list() == []
+    assert service.add("foo") is True
+    assert service.add("foo") is False
+    assert service.list() == ["foo"]
+    assert service.remove("foo") is True
+    assert service.remove("foo") is False


### PR DESCRIPTION
## Summary
- add WatchlistService for high-level watchlist operations
- refactor TelegramWatchlistBot and CLI to use WatchlistService
- cover service and integrations with tests

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1706825c883258bc06cf75126bc04