### PR TITLE
test: update tests for async interfaces

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,7 +66,7 @@ def test_cli_watch_invokes_watcher(
 
     calls: dict[str, Any] = {}
 
-    def fake_watch(
+    async def fake_watch(
         self: container_mod.Watcher,
         logins: LoginsProvider | Sequence[str],
         interval: int,
@@ -122,7 +122,7 @@ def test_cli_graceful_shutdown_sets_stop_and_joins(
     thread_ref: dict[str, Thread] = {}
     stop_holder: dict[str, Event] = {}
 
-    def fake_watch(
+    async def fake_watch(
         self: container_mod.Watcher,
         logins: LoginsProvider | Sequence[str],
         interval: int,
@@ -135,7 +135,7 @@ def test_cli_graceful_shutdown_sets_stop_and_joins(
         _ = report_interval
         thread_ref["thread"] = threading.current_thread()
         stop_holder["event"] = stop_event
-        stop_event.wait()
+        await asyncio.to_thread(stop_event.wait)
 
     monkeypatch.setattr(container_mod.Watcher, "watch", fake_watch, raising=False)
 
@@ -223,7 +223,7 @@ def test_watch_signal_handler(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
     monkeypatch.setattr(container_mod, "TelegramNotifier", DummyNotifier)
     monkeypatch.setattr(container_mod, "TelegramWatchlistBot", DummyBot)
 
-    def fake_watch(
+    async def fake_watch(
         self: container_mod.Watcher,
         logins: LoginsProvider | Sequence[str],
         interval: int,
@@ -287,7 +287,7 @@ def test_watch_bot_exception_exitcode(
     monkeypatch.setattr(container_mod, "TelegramNotifier", DummyNotifier)
     monkeypatch.setattr(container_mod, "TelegramWatchlistBot", DummyBot)
 
-    def fake_watch(
+    async def fake_watch(
         self: container_mod.Watcher,
         logins: LoginsProvider | Sequence[str],
         interval: int,

--- a/tests/test_twitch_client.py
+++ b/tests/test_twitch_client.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import asyncio
 import httpx
 import pytest
 
@@ -59,7 +60,7 @@ def test_get_user_by_login_ok(monkeypatch: pytest.MonkeyPatch, token_ok: None) -
         )
 
     tc = make_client(monkeypatch, fake_get)
-    user = tc.get_user_by_login("foo")
+    user = asyncio.run(tc.get_user_by_login("foo"))
     assert user and user.login == "foo"
     assert user.broadcaster_type == BroadcasterType.PARTNER
 
@@ -84,7 +85,7 @@ def test_401_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
         return FakeResp(200, {"data": []})
 
     tc = make_client(monkeypatch, fake_get)
-    tc.get_user_by_login("foo")
+    asyncio.run(tc.get_user_by_login("foo"))
     assert len(token_calls) == 2
     first, second = calls
     assert first and first["Client-Id"] == "cid"
@@ -105,8 +106,8 @@ def test_refresh_before_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
         return FakeResp(200, {"data": []})
 
     tc = make_client(monkeypatch, fake_get)
-    tc.get_user_by_login("foo")
-    tc.get_user_by_login("bar")
+    asyncio.run(tc.get_user_by_login("foo"))
+    asyncio.run(tc.get_user_by_login("bar"))
     assert token_calls == 2
 
 
@@ -116,7 +117,7 @@ def test_5xx_raises(monkeypatch: pytest.MonkeyPatch, token_ok: None) -> None:
 
     tc = make_client(monkeypatch, fake_get)
     with pytest.raises(httpx.HTTPStatusError):
-        tc.get_user_by_login("foo")
+        asyncio.run(tc.get_user_by_login("foo"))
 
 
 def test_rate_limit(monkeypatch: pytest.MonkeyPatch, token_ok: None) -> None:
@@ -125,7 +126,7 @@ def test_rate_limit(monkeypatch: pytest.MonkeyPatch, token_ok: None) -> None:
 
     tc = make_client(monkeypatch, fake_get)
     with pytest.raises(httpx.HTTPStatusError):
-        tc.get_user_by_login("foo")
+        asyncio.run(tc.get_user_by_login("foo"))
 
 
 def test_timeout(monkeypatch: pytest.MonkeyPatch, token_ok: None) -> None:
@@ -134,7 +135,7 @@ def test_timeout(monkeypatch: pytest.MonkeyPatch, token_ok: None) -> None:
 
     tc = make_client(monkeypatch, fake_get)
     with pytest.raises(httpx.TimeoutException):
-        tc.get_user_by_login("foo")
+        asyncio.run(tc.get_user_by_login("foo"))
 
 
 def test_missing_creds() -> None:
@@ -153,4 +154,4 @@ def test_get_user_none(monkeypatch: pytest.MonkeyPatch, token_ok: None) -> None:
         return FakeResp(200, {"data": []})
 
     tc = make_client(monkeypatch, fake_get)
-    assert tc.get_user_by_login("foo") is None
+    assert asyncio.run(tc.get_user_by_login("foo")) is None


### PR DESCRIPTION
## Summary
- revert synchronous watcher and twitch client changes
- adapt tests to async watcher and twitch client

## Testing
- `uv run --frozen pytest --cov=src --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68bd657af20483259900ddbc3d5e632c