### PR TITLE
Potential fix for code scanning alert no. 130: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nikmosi/twitch-sub-bot/security/code-scanning/130](https://github.com/nikmosi/twitch-sub-bot/security/code-scanning/130)

The correct way to fix this is to add the `permissions:` block at the top level of `.github/workflows/deploy.yml` (immediately after the `name` line or before `jobs:`), minimally setting it to `contents: read` unless more privileges are needed. Since all jobs here appear to only need read access to the repository contents (to checkout the code), and do not perform any GitHub API changes, we will restrict GITHUB_TOKEN to this access level. No changes to individual jobs or steps are needed. No new imports, definitions, or external methods are required, as this is a YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
