### PR TITLE
Potential fix for code scanning alert no. 129: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nikmosi/twitch-sub-bot/security/code-scanning/129](https://github.com/nikmosi/twitch-sub-bot/security/code-scanning/129)

To fix the issue, we need to add a `permissions` block to either the root of the workflow or to the individual job as appropriate. This block should restrict access to the minimal set required for the workflow to operate; in most CI workflows such as this, `contents: read` is usually sufficient, unless a particular step requires write access (e.g., creating issues or PRs). Since the provided workflow only checks out code, runs tests, and uploads coverage (without performing write operations on repository contents), `contents: read` is the best minimal value. Insert the following at the root level just after the `name:` declaration and before the `on:` section in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
